### PR TITLE
Messenger mail overrides: headers + null envelope sender (1.5.3)

### DIFF
--- a/app/messengers/nuntius/base_messenger.rb
+++ b/app/messengers/nuntius/base_messenger.rb
@@ -9,14 +9,16 @@ module Nuntius
 
     define_callbacks :action, terminator: ->(_target, result_lambda) { result_lambda.call == false }
 
-    attr_reader :attachments, :event, :object, :params
-    attr_accessor :templates
+    attr_reader :attachments, :headers, :event, :object, :params
+    attr_accessor :templates, :smtp_envelope_from
 
     def initialize(object, event, params = {})
       @object = object
       @event = event
       @params = params
       @attachments = params.fetch(:attachments, [])
+      @headers = params.fetch(:headers, {})
+      @smtp_envelope_from = params[:smtp_envelope_from]
     end
 
     # Calls the event method on the messenger
@@ -39,6 +41,7 @@ module Nuntius
         @attachments.each do |attachment|
           msg.add_attachment(attachment)
         end
+        apply_mail_overrides(msg)
 
         transport = Nuntius::BaseTransport.class_from_name(template.transport).new
         transport.deliver(msg)
@@ -52,6 +55,12 @@ module Nuntius
 
     def attach(attachment)
       @attachments << attachment
+    end
+
+    # Sets an extra header on the resulting message (currently applied by the
+    # mail transport). Useful for things like "Auto-Submitted" or "Precedence".
+    def header(key, value)
+      @headers[key.to_s] = value
     end
 
     class << self
@@ -172,6 +181,19 @@ module Nuntius
 
     private
 
+    # Persists any messenger-provided mail overrides (extra headers and/or a
+    # custom SMTP envelope sender) onto the message so they survive the
+    # transport delivery job and can be applied by the provider.
+    def apply_mail_overrides(message)
+      return if @headers.blank? && @smtp_envelope_from.nil?
+
+      mail = {}
+      mail["headers"] = @headers if @headers.present?
+      mail["envelope_from"] = @smtp_envelope_from unless @smtp_envelope_from.nil?
+
+      message.metadata = (message.metadata || {}).merge("mail" => mail)
+    end
+
     # Returns the relevant templates for the object / event combination
     def select_templates
       return @templates if @templates
@@ -188,7 +210,7 @@ module Nuntius
 
     def liquid_context
       assigns = @params || {}
-      instance_variables.reject { |i| %w[@params @object @locale @templates @template_scope].include? i.to_s }.each do |i|
+      instance_variables.reject { |i| %w[@params @object @locale @templates @template_scope @headers @smtp_envelope_from].include? i.to_s }.each do |i|
         assigns[i.to_s[1..]] = instance_variable_get(i)
       end
 

--- a/app/providers/nuntius/null_sender_smtp.rb
+++ b/app/providers/nuntius/null_sender_smtp.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "mail"
+
+module Nuntius
+  # A Mail::SMTP delivery method that sends with a null reverse-path
+  # (+MAIL FROM:<>+).
+  #
+  # The stock Mail::SmtpEnvelope refuses to emit an empty reverse-path
+  # (it raises on a blank From), and Net::SMTP wraps the address in angle
+  # brackets, so setting +smtp_envelope_from+ to +"<>"+ would produce the
+  # invalid +MAIL FROM:<<>>+. This delivery method bypasses Mail::SmtpEnvelope
+  # and hands an empty reverse-path straight to Net::SMTP, yielding the
+  # RFC 5321 null sender used by auto-generated/bounce notifications.
+  class NullSenderSmtp < ::Mail::SMTP
+    def deliver!(mail)
+      response = start_smtp_session do |smtp|
+        smtp.sendmail(mail.encoded, "", mail.smtp_envelope_to)
+      end
+
+      settings[:return_response] ? response : self
+    end
+  end
+end

--- a/app/providers/nuntius/smtp_mail_provider.rb
+++ b/app/providers/nuntius/smtp_mail_provider.rb
@@ -6,6 +6,9 @@ module Nuntius
   class SmtpMailProvider < BaseProvider
     transport :mail
 
+    # RFC 5321 null reverse-path, used for auto-generated/bounce notifications.
+    NULL_REVERSE_PATH = "<>"
+
     setting_reader :from_header, required: true, description: "From header (example: Nuntius Messenger <nuntius@entdec.com>)"
     setting_reader :host, required: true, description: "Host (example: smtp.soverin.net)"
     setting_reader :port, required: true, description: "Port (example: 578)"
@@ -32,16 +35,14 @@ module Nuntius
         mail.header["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
       end
 
+      null_sender = apply_mail_overrides(mail)
+
       if Rails.env.test?
         mail.delivery_method :test
+      elsif null_sender
+        mail.delivery_method Nuntius::NullSenderSmtp, smtp_settings
       else
-        mail.delivery_method :smtp,
-          address: host,
-          port: port,
-          user_name: username,
-          password: password,
-          return_response: true,
-          ssl: ssl
+        mail.delivery_method :smtp, smtp_settings
       end
 
       mail.to = message.to
@@ -99,6 +100,45 @@ module Nuntius
     end
 
     private
+
+    def smtp_settings
+      {
+        address: host,
+        port: port,
+        user_name: username,
+        password: password,
+        return_response: true,
+        ssl: ssl
+      }
+    end
+
+    # Applies any messenger-provided overrides stored on the message: extra
+    # headers and/or a custom SMTP envelope sender. Returns true when a null
+    # reverse-path (+MAIL FROM:<>+) was requested, so the caller can pick the
+    # delivery method that can actually emit it.
+    def apply_mail_overrides(mail)
+      overrides = message.metadata&.dig("mail")
+      return false if overrides.blank?
+
+      (overrides["headers"] || {}).each do |key, value|
+        mail.header[key] = value
+      end
+
+      return false unless overrides.key?("envelope_from")
+
+      envelope_from = overrides["envelope_from"]
+      if null_reverse_path?(envelope_from)
+        mail.smtp_envelope_from = NULL_REVERSE_PATH
+        true
+      else
+        mail.smtp_envelope_from = envelope_from
+        false
+      end
+    end
+
+    def null_reverse_path?(value)
+      value.blank? || value == NULL_REVERSE_PATH
+    end
 
     def message_url(message)
       Nuntius::Engine.routes.url_helpers.message_url(message.id, host: Nuntius.config.host(message))

--- a/lib/nuntius/version.rb
+++ b/lib/nuntius/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nuntius
-  VERSION = "1.5.2"
+  VERSION = "1.5.3"
 end

--- a/test/messengers/base_messenger_test.rb
+++ b/test/messengers/base_messenger_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Nuntius
+  class BaseMessengerTest < ActiveSupport::TestCase
+    test "persists headers and a null envelope sender onto the message metadata" do
+      template = create_template
+      messenger = AccountMessenger.new(accounts(:one), :created, {})
+
+      messenger.header("Auto-Submitted", "auto-replied")
+      messenger.header("Precedence", "bulk")
+      messenger.smtp_envelope_from = "<>"
+      messenger.dispatch([template])
+
+      message = Nuntius::Message.where(template: template).last
+      assert_equal "auto-replied", message.metadata.dig("mail", "headers", "Auto-Submitted")
+      assert_equal "bulk", message.metadata.dig("mail", "headers", "Precedence")
+      assert_equal "<>", message.metadata.dig("mail", "envelope_from")
+    end
+
+    test "headers/envelope can be supplied through params" do
+      template = create_template
+      messenger = AccountMessenger.new(
+        accounts(:one), :created,
+        {headers: {"Auto-Submitted" => "auto-replied"}, smtp_envelope_from: "<>"}
+      )
+
+      messenger.dispatch([template])
+
+      message = Nuntius::Message.where(template: template).last
+      assert_equal "auto-replied", message.metadata.dig("mail", "headers", "Auto-Submitted")
+      assert_equal "<>", message.metadata.dig("mail", "envelope_from")
+    end
+
+    test "leaves metadata untouched when no overrides are set" do
+      template = create_template
+      AccountMessenger.new(accounts(:one), :created, {}).dispatch([template])
+
+      message = Nuntius::Message.where(template: template).last
+      assert_nil message.metadata["mail"]
+    end
+
+    private
+
+    def create_template
+      Nuntius::Template.create!(
+        klass: "Account",
+        event: "created",
+        transport: "mail",
+        description: "created",
+        to: "user@example.com",
+        from: "from@example.com",
+        subject: "Hi",
+        text: "Body",
+        enabled: true,
+        metadata: {}
+      )
+    end
+  end
+end

--- a/test/providers/null_sender_smtp_test.rb
+++ b/test/providers/null_sender_smtp_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "minitest/mock"
+
+module Nuntius
+  class NullSenderSmtpTest < ActiveSupport::TestCase
+    test "hands an empty reverse-path to the SMTP session" do
+      delivery = Nuntius::NullSenderSmtp.new(address: "smtp.example.com", port: 25, return_response: false)
+      mail = Mail.new(from: "bounce@example.com", to: "user@example.com", subject: "s", body: "b")
+
+      captured = {}
+      fake_smtp = Object.new
+      fake_smtp.define_singleton_method(:sendmail) do |_message, from, to|
+        captured[:from] = from
+        captured[:to] = to
+        "250 OK"
+      end
+
+      delivery.stub(:start_smtp_session, ->(&block) { block.call(fake_smtp) }) do
+        delivery.deliver!(mail)
+      end
+
+      assert_equal "", captured[:from]
+      assert_includes Array(captured[:to]), "user@example.com"
+    end
+  end
+end

--- a/test/providers/smtp_mail_provider_test.rb
+++ b/test/providers/smtp_mail_provider_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Nuntius
+  class SmtpMailProviderTest < ActiveSupport::TestCase
+    setup do
+      Mail::TestMailer.deliveries.clear
+    end
+
+    test "applies messenger-provided headers to the delivered mail" do
+      message = build_message(metadata: {
+        "mail" => {"headers" => {"Auto-Submitted" => "auto-replied", "Precedence" => "bulk"}}
+      })
+
+      Nuntius::SmtpMailProvider.new(message).deliver
+
+      mail = Mail::TestMailer.deliveries.last
+      assert_equal "auto-replied", mail["Auto-Submitted"].value
+      assert_equal "bulk", mail["Precedence"].value
+    end
+
+    test "uses a null reverse-path when a null envelope sender is requested" do
+      message = build_message(metadata: {"mail" => {"envelope_from" => "<>"}})
+
+      Nuntius::SmtpMailProvider.new(message).deliver
+
+      mail = Mail::TestMailer.deliveries.last
+      assert_equal "<>", mail.smtp_envelope_from
+    end
+
+    test "applies a custom (non-null) envelope sender when requested" do
+      message = build_message(metadata: {"mail" => {"envelope_from" => "bounce@example.com"}})
+
+      Nuntius::SmtpMailProvider.new(message).deliver
+
+      mail = Mail::TestMailer.deliveries.last
+      assert_equal "bounce@example.com", mail.smtp_envelope_from
+    end
+
+    test "does not add overrides for a regular message" do
+      message = build_message
+
+      Nuntius::SmtpMailProvider.new(message).deliver
+
+      mail = Mail::TestMailer.deliveries.last
+      assert_nil mail["Auto-Submitted"]
+      refute_equal "<>", mail.smtp_envelope_from
+    end
+
+    private
+
+    def build_message(metadata: {})
+      Nuntius::Message.new(
+        transport: "mail",
+        provider: "smtp",
+        to: "user@example.com",
+        subject: "Test",
+        text: "Body",
+        metadata: metadata
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adds a generic, reusable seam so messengers can influence the outgoing mail:

- `BaseMessenger#header(key, value)` / `#headers` and `#smtp_envelope_from=` — collected and persisted on `message.metadata["mail"]` (survives the `TransportDeliveryJob` DB reload). Can also be passed via params (`headers:`, `smtp_envelope_from:`).
- `SmtpMailProvider` applies those headers and the envelope sender, selecting a delivery method that can emit the requested envelope.
- New `Nuntius::NullSenderSmtp` delivery method emits a true RFC 5321 null reverse-path (`MAIL FROM:<>`), which the stock `Mail::SmtpEnvelope` refuses to emit (rejects a blank From; net-smtp double-wraps `"<>"` into `<<>>`).

Version bumped to **1.5.3**. Also backported to the 1.3.x line as 1.3.21 (#40).

### Motivation
Consumers need to mark auto-generated messages (e.g. bounce notifications) with `Auto-Submitted: auto-replied` / `Precedence: bulk` and a null envelope sender so mailing-list software (Mailman) doesn't re-broadcast them and loop.

## Test plan
- [x] `test/messengers/base_messenger_test.rb`
- [x] `test/providers/smtp_mail_provider_test.rb`
- [x] `test/providers/null_sender_smtp_test.rb`
- [x] standardrb clean; syntax verified

> Note: the dummy test harness on `main` currently declares `ActiveRecord::Schema[8.1]` while the lockfile installs Rails 8.0.1, so the suite couldn't be executed in my environment. The change is line-for-line equivalent to the 1.3.21 branch whose full suite passes. Please confirm CI is green.

Made with [Cursor](https://cursor.com)