### PR TITLE
Add LMTP delivery transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The main key of the hash passed will also be the liquid variable.
 
 ### Mail
 
-Outbound mail is handled through SMTP. We've only exposed the HTML of mail, we can create text-versions based on sanitized HTML. HTML allows for [Foundation for Emails](https://get.foundation/emails/docs/index.html). You will have to include the CSS in the layouts.
+Outbound mail is handled through SMTP (the `:smtp` provider on the `:mail` transport). LMTP delivery to a mailbox is available through a separate `:lmtp` transport (see below). We've only exposed the HTML of mail, we can create text-versions based on sanitized HTML. HTML allows for [Foundation for Emails](https://get.foundation/emails/docs/index.html). You will have to include the CSS in the layouts.
 
 In the layout you can add `<a href="{{message_url}}">Link to mail</a>` to provide a link to the online version of the message.
 
@@ -243,6 +243,28 @@ The actual URL may be different depending on your routing setup.
 The subscription will automatically be confirmed.
 
 Next in AWS SES, configure the SNS topic to receive feedback notifications for Bounce, Complaint and Delivery and include original headers.
+
+### LMTP
+
+LMTP (RFC 2033) delivers a message directly to a mailbox. It is its own transport, so it never interferes with `:mail`/SMTP delivery. Enable the transport and provider, and give the relevant templates `transport: "lmtp"`:
+
+```ruby
+config.transport :lmtp
+config.provider :lmtp, transport: :lmtp, settings: {
+  from_header: "Example <example@example.com>",
+  allow_list: ["example.com"]
+}
+```
+
+With LMTP both the recipient email address and the target LMTP server are provided by the template, inline-encoded in the `to` field as:
+
+```
+<email>@<host>:<port>
+```
+
+For example a template `to` of `{{user.email}}@mx.internal:24` renders to `user@example.com@mx.internal:24`. The provider uses the email (`user@example.com`) for the `To:` header and the envelope `RCPT TO`, and connects to the LMTP server at `mx.internal:24`. A plain address (without an inline `@host:port`) falls back to the optional `host`/`port` settings.
+
+LMTP templates use the same fields as mail templates (subject, html, layout, tracking). Delivery is synchronous: the server confirms delivery in its reply, so the message is marked `delivered` straight away and no refresh is needed.
 
 ### Slack
 

--- a/app/providers/nuntius/abstract_mail_provider.rb
+++ b/app/providers/nuntius/abstract_mail_provider.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "mail"
+
+module Nuntius
+  # Shared delivery flow for mail providers (SMTP, LMTP). Concrete providers
+  # supply the recipient, the delivery method and the success semantics through
+  # the hooks below.
+  class AbstractMailProvider < BaseProvider
+    transport :mail
+
+    # RFC 5321 null reverse-path, used for auto-generated/bounce notifications.
+    NULL_REVERSE_PATH = "<>"
+
+    def deliver
+      return no_recipient if recipient.blank?
+      return block unless MailAllowList.new(settings[:allow_list]).allowed?(recipient)
+      return block if Nuntius::Message.where(state: %w[complaint bounced], to: recipient).count >= 1
+
+      mail = if message.from.present?
+        Mail.new(sender: from_header, from: message.from)
+      else
+        Mail.new(from: from_header)
+      end
+
+      mail.header["X-Nuntius-Message-Id"] = message.id
+
+      if message.campaign.present? && message.subscriber.present?
+        mail.header["List-Unsubscribe"] = "<" + message.subscriber.unsubscribe_link(message.campaign, message) + ">"
+        mail.header["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+      end
+
+      null_sender = apply_mail_overrides(mail)
+
+      configure_delivery_method(mail, null_sender)
+
+      mail.to = recipient
+      mail.subject = message.subject
+      mail.part content_type: "multipart/alternative" do |p|
+        p.text_part = Mail::Part.new(
+          body: message.text,
+          content_type: "text/plain",
+          charset: "UTF-8"
+        )
+        if message.html.present?
+          # Apply email tracking (tracking pixel and link wrapping)
+          Nuntius::EmailTrackingService.perform(message: message)
+
+          message.html = message.html.gsub("{{message_url}}") { message_url(message) }
+
+          p.html_part = Mail::Part.new(
+            body: message.html,
+            content_type: "text/html",
+            charset: "UTF-8"
+          )
+        end
+      end
+
+      message.attachments.each do |attachment|
+        mail.attachments[attachment.filename.to_s] = {mime_type: attachment.content_type, content: attachment.download}
+      end
+
+      prepare_envelope(mail)
+
+      begin
+        response = mail.deliver!
+      rescue Net::SMTPFatalError
+        message.rejected
+        return message
+      rescue Net::SMTPServerBusy, Net::ReadTimeout
+        message.undelivered
+        return message
+      end
+
+      message.provider_id = mail.message_id
+      message.undelivered
+      message.send(success_state) if Rails.env.test? || delivered_successfully?(response)
+      message.last_sent_at = Time.zone.now if message.sent? || message.delivered?
+
+      message
+    end
+
+    def block
+      message.blocked
+      message
+    end
+
+    def no_recipient
+      message.no_recipient
+      message
+    end
+
+    private
+
+    # The resolved recipient email address. Used for the blank check, allow
+    # list, bounce dedup query and the +To:+ header. Subclasses may override
+    # (e.g. LMTP parses it out of the inline +to+).
+    def recipient
+      message.to
+    end
+
+    # Hook to set a custom SMTP/LMTP envelope. Default lets Mail derive it.
+    def prepare_envelope(mail)
+    end
+
+    # Concrete providers must configure how +mail+ is delivered.
+    def configure_delivery_method(mail, null_sender)
+      raise NotImplementedError, "#{self.class} must implement #configure_delivery_method"
+    end
+
+    # Whether a non-test delivery response counts as success.
+    def delivered_successfully?(response)
+      response.success?
+    end
+
+    # State to transition to on a successful delivery.
+    def success_state
+      :sent
+    end
+
+    # Applies any messenger-provided overrides stored on the message: extra
+    # headers and/or a custom SMTP envelope sender. Returns true when a null
+    # reverse-path (+MAIL FROM:<>+) was requested, so the caller can pick the
+    # delivery method that can actually emit it.
+    def apply_mail_overrides(mail)
+      overrides = message.metadata&.dig("mail")
+      return false if overrides.blank?
+
+      (overrides["headers"] || {}).each do |key, value|
+        mail.header[key] = value
+      end
+
+      return false unless overrides.key?("envelope_from")
+
+      envelope_from = overrides["envelope_from"]
+      if null_reverse_path?(envelope_from)
+        mail.smtp_envelope_from = NULL_REVERSE_PATH
+        true
+      else
+        mail.smtp_envelope_from = envelope_from
+        false
+      end
+    end
+
+    def null_reverse_path?(value)
+      value.blank? || value == NULL_REVERSE_PATH
+    end
+
+    def message_url(message)
+      Nuntius::Engine.routes.url_helpers.message_url(message.id, host: Nuntius.config.host(message))
+    end
+  end
+end

--- a/app/providers/nuntius/lmtp_delivery_method.rb
+++ b/app/providers/nuntius/lmtp_delivery_method.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "socket"
+require "openssl"
+require "net/smtp"
+
+module Nuntius
+  # A minimal LMTP (RFC 2033) delivery method, usable as a Mail delivery
+  # method (+initialize(settings)+ + +deliver!(mail)+).
+  #
+  # Net::SMTP / Mail::SMTP greet with +EHLO+/+HELO+, but LMTP requires +LHLO+
+  # and returns one reply per recipient after the message body, so we speak the
+  # protocol directly over a socket. Failures raise the same Net::SMTP errors
+  # SMTP delivery would, so callers can treat both transports identically.
+  class LmtpDeliveryMethod
+    Response = Struct.new(:code, :message) do
+      def success?
+        code.to_s.start_with?("2")
+      end
+    end
+
+    DEFAULTS = {
+      address: "localhost",
+      port: 24,
+      ssl: false,
+      domain: "localhost"
+    }.freeze
+
+    attr_reader :settings
+
+    def initialize(settings = {})
+      @settings = DEFAULTS.merge(settings.compact)
+    end
+
+    def deliver!(mail)
+      envelope_from = mail.smtp_envelope_from
+      destinations = Array(mail.smtp_envelope_to)
+      raise ArgumentError, "LMTP delivery requires at least one recipient" if destinations.empty?
+
+      data = mail.encoded
+      socket = open_socket
+      begin
+        read_reply(socket, expected: "2") # 220 greeting
+        send_command(socket, "LHLO #{settings[:domain]}", expected: "2")
+        send_command(socket, "MAIL FROM:<#{envelope_from}>", expected: "2")
+        destinations.each do |to|
+          send_command(socket, "RCPT TO:<#{to}>", expected: "2")
+        end
+
+        send_command(socket, "DATA", expected: "3") # 354
+        socket.write(dot_stuff(data))
+        socket.write("\r\n") unless data.end_with?("\r\n")
+        socket.write(".\r\n")
+
+        # LMTP returns one reply per recipient after the body.
+        response = nil
+        destinations.each do
+          response = read_reply(socket, expected: "2")
+        end
+
+        send_command(socket, "QUIT", expected: nil)
+        response
+      ensure
+        socket.close unless socket.closed?
+      end
+    end
+
+    private
+
+    def open_socket
+      tcp = TCPSocket.open(settings[:address], settings[:port])
+      return tcp unless settings[:ssl]
+
+      ssl = OpenSSL::SSL::SSLSocket.new(tcp)
+      ssl.sync_close = true
+      ssl.connect
+      ssl
+    end
+
+    def send_command(socket, command, expected:)
+      socket.write("#{command}\r\n")
+      read_reply(socket, expected: expected)
+    end
+
+    def read_reply(socket, expected:)
+      lines = []
+      code = nil
+      loop do
+        line = socket.gets
+        raise Net::SMTPFatalError, "LMTP connection closed unexpectedly" if line.nil?
+
+        line = line.chomp
+        lines << line
+        code = line[0, 3]
+        # Multiline replies use "250-..." for every line but the last ("250 ...").
+        break unless line[3] == "-"
+      end
+
+      response = Response.new(code, lines.join("\n"))
+      return response if expected.nil? || code.to_s.start_with?(expected)
+
+      raise_for(code, response.message)
+    end
+
+    def raise_for(code, message)
+      case code.to_s[0]
+      when "4"
+        raise Net::SMTPServerBusy, message
+      when "5"
+        raise Net::SMTPFatalError, message
+      else
+        raise Net::SMTPUnknownError, message
+      end
+    end
+
+    # RFC 5321 transparency: lines starting with a dot get an extra dot.
+    def dot_stuff(data)
+      data.gsub(/^\./, "..")
+    end
+  end
+end

--- a/app/providers/nuntius/lmtp_lmtp_provider.rb
+++ b/app/providers/nuntius/lmtp_lmtp_provider.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "mail"
+
+module Nuntius
+  # Delivers mail to a mailbox over LMTP.
+  #
+  # The recipient and the per-message LMTP server are inline-encoded in the
+  # message +to+ as <tt><email>@<host>:<port></tt> (for example
+  # <tt>user@example.com@mx.internal:24</tt>). The +email+ is used for the
+  # +To:+ header and the envelope +RCPT TO+; the +host:port+ is the LMTP
+  # server we connect to. A plain address (without +@host:port+) falls back to
+  # the configured +host+/+port+ settings.
+  #
+  # Delivery is synchronous: the server's per-recipient reply is the final
+  # confirmation, so messages are marked +delivered+ directly and no refresh
+  # job is required.
+  class LmtpLmtpProvider < AbstractMailProvider
+    transport :lmtp
+
+    LMTP_TARGET = /\A(?<email>.+)@(?<host>[^@\s:]+):(?<port>\d+)\z/
+
+    setting_reader :from_header, required: true, description: "From header (example: Nuntius Messenger <nuntius@entdec.com>)"
+    setting_reader :host, required: false, default: nil, description: "Fallback LMTP host, used when not encoded in the recipient (example: 127.0.0.1)"
+    setting_reader :port, required: false, default: nil, description: "Fallback LMTP port, used when not encoded in the recipient (example: 24)"
+    setting_reader :allow_list, required: false, default: [], description: "Allow list (example: [example.com, tim@apple.com])"
+    setting_reader :ssl, required: false, default: false, description: "Whether to use SSL or not"
+
+    private
+
+    def recipient
+      lmtp_target[:email]
+    end
+
+    def prepare_envelope(mail)
+      mail.smtp_envelope_to = recipient
+    end
+
+    def configure_delivery_method(mail, _null_sender)
+      if Rails.env.test?
+        mail.delivery_method :test
+      else
+        mail.delivery_method Nuntius::LmtpDeliveryMethod, lmtp_settings
+      end
+    end
+
+    # LMTP delivery is synchronous and confirmed by the server, so we can mark
+    # the message delivered straight away (no refresh job needed).
+    def success_state
+      :delivered
+    end
+
+    def lmtp_settings
+      {
+        address: lmtp_target[:host],
+        port: lmtp_target[:port],
+        ssl: ssl
+      }
+    end
+
+    def lmtp_target
+      @lmtp_target ||= begin
+        match = message.to.to_s.strip.match(LMTP_TARGET)
+        if match
+          {email: match[:email], host: match[:host], port: match[:port].to_i}
+        else
+          {email: message.to, host: host, port: port}
+        end
+      end
+    end
+  end
+end

--- a/app/providers/nuntius/smtp_mail_provider.rb
+++ b/app/providers/nuntius/smtp_mail_provider.rb
@@ -3,11 +3,8 @@
 require "mail"
 
 module Nuntius
-  class SmtpMailProvider < BaseProvider
+  class SmtpMailProvider < AbstractMailProvider
     transport :mail
-
-    # RFC 5321 null reverse-path, used for auto-generated/bounce notifications.
-    NULL_REVERSE_PATH = "<>"
 
     setting_reader :from_header, required: true, description: "From header (example: Nuntius Messenger <nuntius@entdec.com>)"
     setting_reader :host, required: true, description: "Host (example: smtp.soverin.net)"
@@ -17,26 +14,9 @@ module Nuntius
     setting_reader :allow_list, required: false, default: [], description: "Allow list (example: [example.com, tim@apple.com])"
     setting_reader :ssl, required: false, default: false, description: "Whether to use SSL or not"
 
-    def deliver
-      return no_recipient if message.to.blank?
-      return block unless MailAllowList.new(settings[:allow_list]).allowed?(message.to)
-      return block if Nuntius::Message.where(state: %w[complaint bounced], to: message.to).count >= 1
+    private
 
-      mail = if message.from.present?
-        Mail.new(sender: from_header, from: message.from)
-      else
-        Mail.new(from: from_header)
-      end
-
-      mail.header["X-Nuntius-Message-Id"] = message.id
-
-      if message.campaign.present? && message.subscriber.present?
-        mail.header["List-Unsubscribe"] = "<" + message.subscriber.unsubscribe_link(message.campaign, message) + ">"
-        mail.header["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
-      end
-
-      null_sender = apply_mail_overrides(mail)
-
+    def configure_delivery_method(mail, null_sender)
       if Rails.env.test?
         mail.delivery_method :test
       elsif null_sender
@@ -44,62 +24,7 @@ module Nuntius
       else
         mail.delivery_method :smtp, smtp_settings
       end
-
-      mail.to = message.to
-      mail.subject = message.subject
-      mail.part content_type: "multipart/alternative" do |p|
-        p.text_part = Mail::Part.new(
-          body: message.text,
-          content_type: "text/plain",
-          charset: "UTF-8"
-        )
-        if message.html.present?
-          # Apply email tracking (tracking pixel and link wrapping)
-          Nuntius::EmailTrackingService.perform(message: message)
-
-          message.html = message.html.gsub("{{message_url}}") { message_url(message) }
-
-          p.html_part = Mail::Part.new(
-            body: message.html,
-            content_type: "text/html",
-            charset: "UTF-8"
-          )
-        end
-      end
-
-      message.attachments.each do |attachment|
-        mail.attachments[attachment.filename.to_s] = {mime_type: attachment.content_type, content: attachment.download}
-      end
-
-      begin
-        response = mail.deliver!
-      rescue Net::SMTPFatalError
-        message.rejected
-        return message
-      rescue Net::SMTPServerBusy, Net::ReadTimeout
-        message.undelivered
-        return message
-      end
-
-      message.provider_id = mail.message_id
-      message.undelivered
-      message.sent if Rails.env.test? || response.success?
-      message.last_sent_at = Time.zone.now if message.sent?
-
-      message
     end
-
-    def block
-      message.blocked
-      message
-    end
-
-    def no_recipient
-      message.no_recipient
-      message
-    end
-
-    private
 
     def smtp_settings
       {
@@ -110,38 +35,6 @@ module Nuntius
         return_response: true,
         ssl: ssl
       }
-    end
-
-    # Applies any messenger-provided overrides stored on the message: extra
-    # headers and/or a custom SMTP envelope sender. Returns true when a null
-    # reverse-path (+MAIL FROM:<>+) was requested, so the caller can pick the
-    # delivery method that can actually emit it.
-    def apply_mail_overrides(mail)
-      overrides = message.metadata&.dig("mail")
-      return false if overrides.blank?
-
-      (overrides["headers"] || {}).each do |key, value|
-        mail.header[key] = value
-      end
-
-      return false unless overrides.key?("envelope_from")
-
-      envelope_from = overrides["envelope_from"]
-      if null_reverse_path?(envelope_from)
-        mail.smtp_envelope_from = NULL_REVERSE_PATH
-        true
-      else
-        mail.smtp_envelope_from = envelope_from
-        false
-      end
-    end
-
-    def null_reverse_path?(value)
-      value.blank? || value == NULL_REVERSE_PATH
-    end
-
-    def message_url(message)
-      Nuntius::Engine.routes.url_helpers.message_url(message.id, host: Nuntius.config.host(message))
     end
   end
 end

--- a/app/transports/nuntius/lmtp_transport.rb
+++ b/app/transports/nuntius/lmtp_transport.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Nuntius
+  # LMTP delivers actual email, so it shares all mail processing (premailer,
+  # per-recipient splitting) with MailTransport. Only the configured providers
+  # differ: the :lmtp transport routes to the LMTP provider.
+  class LmtpTransport < MailTransport
+  end
+end

--- a/app/views/nuntius/admin/templates/edit.html.slim
+++ b/app/views/nuntius/admin/templates/edit.html.slim
@@ -61,6 +61,18 @@
             .col-span-12
               = f.input :html, as: :editor, mode: 'text/markdown', height: '400px'
 
+          template data-toggle-target='toggleable' data-toggle-value='lmtp'
+            .col-span-6
+              = f.input :link_tracking, as: :switch
+            .col-span-6
+              = f.input :open_tracking, as: :switch
+            .col-span-12
+              = f.input :subject, as: :editor, mode: 'text/plain'
+            .col-span-12
+              = f.association :layout, collection: @layouts, include_blank: true
+            .col-span-12
+              = f.input :html, as: :editor, mode: 'text/markdown', height: '400px'
+
           template data-toggle-target='toggleable' data-toggle-value='voice'
             .col-span-12
               = f.input :text, as: :editor, mode: 'text/plain', height: '400px'

--- a/lib/generators/nuntius/templates/config/initializers/nuntius.rb
+++ b/lib/generators/nuntius/templates/config/initializers/nuntius.rb
@@ -21,6 +21,17 @@ Nuntius.setup do |config|
     }
   }
 
+  # LMTP delivery to a mailbox, on its own `:lmtp` transport. Enable the
+  # transport and provider, then give such templates `transport: "lmtp"`. The
+  # recipient and per-message LMTP server are inline-encoded in the template
+  # `to` as `<email>@<host>:<port>`, e.g. `user@example.com@mx.internal:24`.
+  # `host`/`port` here are optional fallbacks for plain addresses.
+  # config.transport :lmtp
+  # config.provider :lmtp, transport: :lmtp, settings: {
+  #   from_header: "Example <example@example.com>",
+  #   allow_list: ["example.com"]
+  # }
+
   config.provider :houston, transport: :push, settings: {certificate: ""}
   config.provider :firebase, transport: :push, settings: {server_key: ""}
 

--- a/test/dummy/config/initializers/nuntius.rb
+++ b/test/dummy/config/initializers/nuntius.rb
@@ -5,6 +5,7 @@ Nuntius.setup do |config|
   config.logger = -> { Rails.logger }
 
   config.transport :mail
+  config.transport :lmtp
   config.transport :push
   config.transport :sms
   config.transport :voice
@@ -19,6 +20,15 @@ Nuntius.setup do |config|
       password: "",
       allow_list: ["example.com"]
     }
+  }
+
+  # LMTP delivery to a mailbox, on its own transport. The recipient and
+  # per-message LMTP server are inline-encoded in the template `to` as
+  # `<email>@<host>:<port>`; `host`/`port` are optional fallbacks for plain
+  # addresses.
+  config.provider :lmtp, transport: :lmtp, settings: {
+    from_header: "Example <example@example.com>",
+    allow_list: ["example.com"]
   }
 
   config.provider :houston, transport: :push, settings: {certificate: ""}

--- a/test/models/nuntius/message_test.rb
+++ b/test/models/nuntius/message_test.rb
@@ -27,6 +27,22 @@ module Nuntius
       end
     end
 
+    test "delivering an lmtp message routes through the lmtp transport and provider" do
+      message = Nuntius::Message.create!(transport: "lmtp", to: "user@example.com@mx.internal:24", html: "Hi", text: "Hi")
+
+      perform_enqueued_jobs do
+        message.deliver_as(:lmtp)
+
+        assert_equal "lmtp", message.reload.provider
+        assert message.reload.delivered?
+
+        assert_equal 1, Mail::TestMailer.deliveries.length
+        mail = Mail::TestMailer.deliveries.first
+        assert_equal ["user@example.com"], mail.to
+        assert_equal ["user@example.com"], mail.smtp_envelope_to
+      end
+    end
+
     test "delivering a message that does not match the allow list will block it" do
       message = nuntius_messages(:blocked_recipient)
 

--- a/test/providers/lmtp_delivery_method_test.rb
+++ b/test/providers/lmtp_delivery_method_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "socket"
+
+module Nuntius
+  class LmtpDeliveryMethodTest < ActiveSupport::TestCase
+    test "performs the LMTP conversation and returns a successful response" do
+      received = []
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.addr[1]
+
+      server_thread = Thread.new do
+        client = server.accept
+        client.print "220 lmtp ready\r\n"
+        received << client.gets # LHLO
+        client.print "250-lmtp greets you\r\n250 PIPELINING\r\n"
+        received << client.gets # MAIL FROM
+        client.print "250 2.1.0 Ok\r\n"
+        received << client.gets # RCPT TO
+        client.print "250 2.1.5 Ok\r\n"
+        received << client.gets # DATA
+        client.print "354 End data with <CR><LF>.<CR><LF>\r\n"
+        loop do
+          line = client.gets
+          break if line.nil? || line == ".\r\n"
+        end
+        client.print "250 2.0.0 <user@example.com> delivered\r\n"
+        received << client.gets # QUIT
+        client.print "221 2.0.0 Bye\r\n"
+        client.close
+      ensure
+        server.close
+      end
+
+      response = Nuntius::LmtpDeliveryMethod.new(address: "127.0.0.1", port: port, domain: "test.local").deliver!(build_mail)
+      server_thread.join(2)
+
+      assert response.success?
+      assert_equal "LHLO test.local\r\n", received[0]
+      assert_equal "MAIL FROM:<from@example.com>\r\n", received[1]
+      assert_equal "RCPT TO:<user@example.com>\r\n", received[2]
+      assert_equal "DATA\r\n", received[3]
+      assert_equal "QUIT\r\n", received[4]
+    end
+
+    test "raises Net::SMTPFatalError on a 5xx reply" do
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.addr[1]
+
+      server_thread = Thread.new do
+        client = server.accept
+        client.print "220 lmtp ready\r\n"
+        client.gets # LHLO
+        client.print "250 lmtp\r\n"
+        client.gets # MAIL FROM
+        client.print "550 5.1.0 Sender rejected\r\n"
+        client.close
+      ensure
+        server.close
+      end
+
+      method = Nuntius::LmtpDeliveryMethod.new(address: "127.0.0.1", port: port)
+
+      assert_raises(Net::SMTPFatalError) do
+        method.deliver!(build_mail)
+      end
+
+      server_thread.join(2)
+    end
+
+    private
+
+    def build_mail
+      mail = Mail.new do
+        from "from@example.com"
+        to "user@example.com"
+        subject "Hi"
+        body "Hello there"
+      end
+      mail.smtp_envelope_from = "from@example.com"
+      mail.smtp_envelope_to = "user@example.com"
+      mail
+    end
+  end
+end

--- a/test/providers/lmtp_lmtp_provider_test.rb
+++ b/test/providers/lmtp_lmtp_provider_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Nuntius
+  class LmtpLmtpProviderTest < ActiveSupport::TestCase
+    setup do
+      Mail::TestMailer.deliveries.clear
+    end
+
+    test "parses the inline <email>@<host>:<port> recipient" do
+      provider = Nuntius::LmtpLmtpProvider.new(build_message(to: "user@example.com@mx.internal:24"))
+
+      target = provider.send(:lmtp_target)
+      assert_equal "user@example.com", target[:email]
+      assert_equal "mx.internal", target[:host]
+      assert_equal 24, target[:port]
+    end
+
+    test "delivers to the email address while routing to the inline server" do
+      message = build_message(to: "user@example.com@mx.internal:24")
+
+      Nuntius::LmtpLmtpProvider.new(message).deliver
+
+      mail = Mail::TestMailer.deliveries.last
+      assert_equal ["user@example.com"], mail.to
+      assert_equal ["user@example.com"], mail.smtp_envelope_to
+    end
+
+    test "marks the message delivered immediately (no refresh job needed)" do
+      message = build_message(to: "user@example.com@mx.internal:24")
+
+      Nuntius::LmtpLmtpProvider.new(message).deliver
+
+      assert message.delivered?
+      refute message.sent?
+    end
+
+    test "falls back to the configured host/port for a plain address" do
+      provider = Nuntius::LmtpLmtpProvider.new(build_message(to: "user@example.com"))
+
+      provider.stub(:host, "127.0.0.1") do
+        provider.stub(:port, 24) do
+          target = provider.send(:lmtp_target)
+          assert_equal "user@example.com", target[:email]
+          assert_equal "127.0.0.1", target[:host]
+          assert_equal 24, target[:port]
+        end
+      end
+    end
+
+    test "blocks a recipient that is not on the allow list" do
+      message = build_message(to: "user@blocked.test@mx.internal:24")
+
+      Nuntius::LmtpLmtpProvider.new(message).deliver
+
+      assert message.blocked?
+      assert_equal 0, Mail::TestMailer.deliveries.length
+    end
+
+    test "blocks a recipient that previously bounced" do
+      Nuntius::Message.create!(transport: "lmtp", to: "bouncer@example.com", html: "x", text: "x", state: "bounced")
+      message = build_message(to: "bouncer@example.com@mx.internal:24")
+
+      Nuntius::LmtpLmtpProvider.new(message).deliver
+
+      assert message.blocked?
+      assert_equal 0, Mail::TestMailer.deliveries.length
+    end
+
+    private
+
+    def build_message(to:, metadata: {})
+      Nuntius::Message.new(
+        transport: "lmtp",
+        provider: "lmtp",
+        to: to,
+        subject: "Test",
+        text: "Body",
+        metadata: metadata
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a separate `:lmtp` transport for delivering mail directly to a mailbox over LMTP (RFC 2033), alongside the existing `:mail`/SMTP transport. Because it is its own transport, it never interferes with SMTP delivery.

- **Shared mail flow**: extracted the common delivery logic from `SmtpMailProvider` into a new `AbstractMailProvider` with hooks (`recipient`, `prepare_envelope`, `configure_delivery_method`, `delivered_successfully?`, `success_state`). `SmtpMailProvider` now inherits it with identical behavior.
- **LMTP provider**: `LmtpLmtpProvider` (on the `:lmtp` transport, mirroring `SlackSlackProvider` on `:slack`). The recipient email and per-message LMTP server are inline-encoded in the template `to` as `<email>@<host>:<port>` (e.g. `user@example.com@mx.internal:24`). The email is used for the `To:` header and envelope `RCPT TO`; the `host:port` is the server to connect to. Plain addresses fall back to optional `host`/`port` settings.
- **LMTP client**: `LmtpDeliveryMethod`, a minimal TCP client that speaks `LHLO` (Net::SMTP/Mail only speak EHLO) and raises the same `Net::SMTP*` errors so state mapping matches SMTP.
- **Synchronous delivery**: the LMTP server confirms delivery in its reply, so messages are marked `delivered` immediately and no `TransportRefreshJob` is scheduled.
- **Transport + UI**: `LmtpTransport` reuses `MailTransport` processing (premailer, per-recipient splitting). The template admin form gains an `lmtp` block mirroring the mail fields (subject, html, layout, tracking).
- **Config**: `config.transport :lmtp` + `config.provider :lmtp, transport: :lmtp` (dummy initializer active; generator template documented).

No migrations or model changes.

## Test plan

- [x] `bin/rails test` — full suite green (0 failures/errors)
- [x] `standardrb` clean on changed files
- [x] Existing SMTP provider tests pass unchanged (refactor is behavior-preserving)
- [x] New `LmtpLmtpProvider` unit tests: inline parsing, delivery to email while routing to inline server, `delivered` state, host/port fallback, allow-list + bounce blocking
- [x] New `LmtpDeliveryMethod` tests: LHLO/MAIL FROM/RCPT TO/DATA conversation against a fake TCP server, and `5xx` raises `Net::SMTPFatalError`
- [x] Integration test: `deliver_as(:lmtp)` routes through `LmtpTransport` -> `LmtpLmtpProvider` and delivers

Made with [Cursor](https://cursor.com)