### PR TITLE
Inherit locale and template_scope in subclassed messengers

### DIFF
--- a/app/messengers/nuntius/base_messenger.rb
+++ b/app/messengers/nuntius/base_messenger.rb
@@ -145,12 +145,16 @@ module Nuntius
 
       def locale(locale = nil)
         @locale = locale if locale
-        @locale
+        return @locale if defined?(@locale) && @locale
+
+        superclass.respond_to?(:locale) ? superclass.locale : nil
       end
 
       def template_scope(template_scope = nil)
         @template_scope = template_scope if template_scope
-        @template_scope
+        return @template_scope if defined?(@template_scope) && @template_scope
+
+        superclass.respond_to?(:template_scope) ? superclass.template_scope : nil
       end
 
       def timebased_scopes

--- a/test/messengers/messenger_inheritance_test.rb
+++ b/test/messengers/messenger_inheritance_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Nuntius
+  class MessengerInheritanceTest < ActiveSupport::TestCase
+    class ScopedParentMessenger < Nuntius::BaseMessenger
+      locale ->(_object) { :nl }
+      template_scope ->(_object) { where(enabled: true) }
+    end
+
+    class InheritingChildMessenger < ScopedParentMessenger
+    end
+
+    test "subclass inherits locale from its parent messenger" do
+      assert_equal ScopedParentMessenger.locale, InheritingChildMessenger.locale
+      assert_not_nil InheritingChildMessenger.locale
+    end
+
+    test "subclass inherits template_scope from its parent messenger" do
+      assert_equal ScopedParentMessenger.template_scope, InheritingChildMessenger.template_scope
+      assert_not_nil InheritingChildMessenger.template_scope
+    end
+
+    test "overriding template_scope on a subclass does not mutate the parent" do
+      overriding = Class.new(ScopedParentMessenger)
+      own_scope = ->(_object) { none }
+      overriding.template_scope(own_scope)
+
+      assert_equal own_scope, overriding.template_scope
+      refute_equal own_scope, ScopedParentMessenger.template_scope
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`BaseMessenger.locale` and `BaseMessenger.template_scope` store their value in a **class-instance variable** and returned only what was set directly on the receiving class. Because class-instance variables are not inherited, a messenger that subclasses another (for example an STI-derived messenger) silently returned `nil` for these — losing its parent's configuration.

The concrete impact downstream: a subclassed messenger with no explicit `template_scope` caused `select_templates` to skip the scope entirely (the default template scope is unrestricted), so template selection ran across **all** records instead of the intended (e.g. per-label) subset.

This changes both getters to fall back to the superclass value when the subclass has not set its own, walking up the ancestry until a `BaseMessenger` descendant is found. Setting a value on a subclass still only affects that subclass (no parent mutation).

## Changes

- `locale` / `template_scope`: return own value if set, otherwise delegate to `superclass`.
- New `test/messengers/messenger_inheritance_test.rb` covering:
  - a subclass inherits `locale` from its parent messenger
  - a subclass inherits `template_scope` from its parent messenger
  - overriding `template_scope` on a subclass does not mutate the parent

## Test plan

- [x] `bin/rails test test/messengers test/life_cycle_test.rb test/state_machine_test.rb test/models/nuntius/template_test.rb` (0 failures)
- [x] New inheritance test fails before the fix (subclass returns `nil`) and passes after

Made with [Cursor](https://cursor.com)